### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://kcrnac.visualstudio.com/1b8d4f4e-f09e-47df-94b4-c448701a73f7/5e7ad76b-9c98-45ab-a53e-ec41a5f12cc4/_apis/work/boardbadge/b413c2de-9633-485b-975c-1a98148c3991)](https://kcrnac.visualstudio.com/1b8d4f4e-f09e-47df-94b4-c448701a73f7/_boards/board/t/5e7ad76b-9c98-45ab-a53e-ec41a5f12cc4/Microsoft.RequirementCategory)
 ![ng-instagram image](https://github.com/kcrnac/ng-instagram/blob/master/resources/images/cover.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#39](https://kcrnac.visualstudio.com/1b8d4f4e-f09e-47df-94b4-c448701a73f7/_workitems/edit/39). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.